### PR TITLE
lab2c - pass test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # Labs for MIT's 6.824/6.5840 Distributed System - 2023 Spring
 
+To run a test many times in parallel (for Lab 2 now):
+
+```bash
+# go to src/raft
+# run the test `500` times, with `32` workers and `2C` as test filter (i.e., value passed to `go test`'s `-run` flag)
+$ ./go-test-many.sh 500 32 2C
+```
+
 - [x] [Lab 1: MapReduce](https://pdos.csail.mit.edu/6.824/labs/lab-mr.html)
 - [x] [Lab 2: Raft](https://pdos.csail.mit.edu/6.824/labs/lab-raft.html)
   - [x] Lab 2A: LeaderElection and Heartbeat [pass 1000/1000]
   - [x] Lab 2B: AppendEntries for leaders and followers [pass 1000/1000]
-  - [ ] Lab 2C: Persist Raft data
+  - [x] Lab 2C: Persist Raft data [pass 497~500/500, rare failure means an optimization might necessary]
   - [ ] Lab 2D: log compaction
 - [ ] [Lab 3: Key-Value storage based on Raft](https://pdos.csail.mit.edu/6.824/labs/lab-kvraft.html)
   - [ ] Lab 3A: KV storage without snapshots

--- a/src/raft/types.go
+++ b/src/raft/types.go
@@ -34,6 +34,11 @@ type AppendEntriesArgs struct {
 type AppendEntriesReply struct {
 	Term    int
 	Success bool
+
+	// For nextIndex backup optimization
+	XTerm  int // term in the conflicting entry (if any)
+	XIndex int // index of first entry with that term (if any)
+	XLen   int // log length
 }
 
 // LogEntry is a log entry in the log.


### PR DESCRIPTION
This PR completes lab 2c - persistence:

1. `persist` persistent raft state whenever they're modified.
2. retry the 2 RPC calls (`sendRequestVote` and `sendAppendEntries`) if they failed (by sleeping 10ms).
3. optimized `nextIndex` backtrack.