### PR TITLE
lab2d - pass all lab2 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ $ ./go-test-many.sh 500 32 2C
 ```
 
 - [x] [Lab 1: MapReduce](https://pdos.csail.mit.edu/6.824/labs/lab-mr.html)
-- [x] [Lab 2: Raft](https://pdos.csail.mit.edu/6.824/labs/lab-raft.html)
+- [x] [Lab 2: Raft](https://pdos.csail.mit.edu/6.824/labs/lab-raft.html) [pass 99/100 test runs (`./go-test-many.sh 100 20 2`)]
   - [x] Lab 2A: LeaderElection and Heartbeat [pass 1000/1000]
   - [x] Lab 2B: AppendEntries for leaders and followers [pass 1000/1000]
   - [x] Lab 2C: Persist Raft data [pass 497~500/500, rare failure means an optimization might necessary]
-  - [ ] Lab 2D: log compaction
+  - [x] Lab 2D: log compaction
 - [ ] [Lab 3: Key-Value storage based on Raft](https://pdos.csail.mit.edu/6.824/labs/lab-kvraft.html)
   - [ ] Lab 3A: KV storage without snapshots
   - [ ] Lab 3B: KV storage with snapshots

--- a/src/raft/candidate.go
+++ b/src/raft/candidate.go
@@ -1,1 +1,0 @@
-package raft

--- a/src/raft/follower.go
+++ b/src/raft/follower.go
@@ -1,1 +1,0 @@
-package raft

--- a/src/raft/leader-election.go
+++ b/src/raft/leader-election.go
@@ -1,0 +1,211 @@
+package raft
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// ticker runs in the background to check if a leader election should be started.
+// Its main logic is a `for` loop that:
+// 1. Reset the `receiveHB` flag;
+// 2. Start a randomized election timeout;
+// 3. Check if a leader election should be started.
+//
+// A given `ticker` gorouotine is binded to a follower/candidate in a given term,
+// and ends when either the status or the term is changed.
+//
+// It's created when:
+// 1. A Raft instance is created by `Make()` (none -> follower);
+// 2. leader -> follower
+// 3. candidate -> follower
+// 4. follower -> candidate
+// 2-4 will end existing `ticker` gorouotine because of the status/term change.
+func (rf *Raft) ticker() {
+	rf.mu.Lock()
+	startTerm, startStatus := rf.currentTerm, rf.role
+	rf.mu.Unlock()
+	if startStatus == LEADER {
+		return
+	}
+
+	DPrintf("[ticker.start] %d, term: %d, role: %s\n", rf.me, startTerm, startStatus)
+
+	for rf.killed() == false {
+		// Your code here (2A)
+		// Check if a leader election should be started.
+
+		// 1. Reset the HB receive flag before starting election timeout.
+		rf.mu.Lock()
+		rf.receiveHB = false
+		rf.mu.Unlock()
+
+		// 2. Randomize the election timeout duration.
+		timeout := time.Duration(ELECTION_TIMEOUT_MIN+rand.Int63()%ELECTION_TIMEOUT_JIT) * time.Millisecond
+		time.Sleep(timeout)
+
+		// 3. Start leader election if not yet a leader and not receive HB.
+		rf.mu.Lock()
+		if rf.role == LEADER {
+			rf.mu.Unlock()
+			DPrintf("[ticker.end] %d, term: %d -> %d, role: %s -> %s\n", rf.me, startTerm, rf.currentTerm, startStatus, rf.role)
+			break
+		}
+		if !rf.receiveHB {
+			go rf.startLeaderElection()
+		}
+		rf.mu.Unlock()
+	}
+}
+
+// startLeaderElection initiates a leader election by updating the Raft node's
+// metadata, and sending RequestVote RPCs to all other nodes.
+func (rf *Raft) startLeaderElection() {
+	// Lock only the duration of changing the Raft node's metadata, so it can
+	// still receive RPCs and potentially discover a leader or a candidate
+	// with higher term.
+	rf.mu.Lock()
+	rf.becomeCandidate(rf.currentTerm + 1)
+	// Record necessary metadata for this term's RequestVote RPCs.
+	term := rf.currentTerm
+	lastLogTerm, lastLogIndex := rf.lastLogTermIndex()
+	rf.mu.Unlock()
+
+	DPrintf("[startLeaderElection.start] %d, term: %d\n", rf.me, term)
+
+	var cond = sync.NewCond(&rf.mu)
+
+	// Send RequestVote RPCs to all other nodes.
+	for i := range rf.peers {
+		if i == rf.me {
+			continue
+		}
+
+		i := i
+		request := RequestVoteArgs{
+			Term:         term,
+			CandidateId:  rf.me,
+			LastLogTerm:  lastLogTerm,
+			LastLogIndex: lastLogIndex,
+		}
+
+		go func() {
+			var reply RequestVoteReply
+			ok := false
+			for !rf.killed() {
+				reply = RequestVoteReply{}
+				if ok = rf.sendRequestVote(i, &request, &reply); ok {
+					break
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			rf.mu.Lock()
+			defer rf.mu.Unlock()
+			rf.voteReceived++
+			if ok {
+				if !rf.checkTermAndRole(request.Term, CANDIDATE) {
+					return
+				}
+				if reply.VoteGranted {
+					rf.voteGranted++
+				}
+				if reply.Term > rf.currentTerm {
+					rf.becomeFollower(reply.Term)
+				}
+				// don't need `broadcast`, since only the main goroutine is waiting.
+				cond.Broadcast()
+			}
+		}()
+	}
+
+	// Check election result whenever a vote is received. Wait while we cannot make a decision:
+	// 1. Haven't received a majority of votes.
+	// 2. The Raft node's term has been changed (e.g., a leader is found, or a new election is initiated).
+	// 3. A higher term is discovered from other nodes' RequestVote RPC replies.
+	rf.mu.Lock()
+	for rf.checkTermAndRole(term, CANDIDATE) && rf.voteGranted <= len(rf.peers)/2 && rf.voteReceived < len(rf.peers) {
+		cond.Wait()
+	}
+	defer rf.mu.Unlock()
+
+	// If after sending RequestVote RPCs, the Raft node is no longer a candidate,
+	// or not in the same term, return directly since this election has expired.
+
+	DPrintf("[startLeaderElection.end] %d, term: %d -> %d, vote granted: %d, vote received: %d\n", rf.me, term, rf.currentTerm, rf.voteGranted, rf.voteReceived)
+
+	switch {
+	case !rf.checkTermAndRole(term, CANDIDATE):
+		// This election has expired, e.g., observing a new leader or a higher term.
+		return
+	case rf.voteGranted > len(rf.peers)/2:
+		// Win the election
+		rf.becomeLeader(rf.currentTerm)
+	default:
+		// Neither observer newer term nor win the election.
+		// Do nothing in this round of leader election.
+		// The next election timeout will start a new leader election.
+	}
+}
+
+// example code to send a RequestVote RPC to a server.
+// server is the index of the target server in rf.peers[].
+// expects RPC arguments in args.
+// fills in *reply with RPC reply, so caller should
+// pass &reply.
+// the types of the args and reply passed to Call() must be
+// the same as the types of the arguments declared in the
+// handler function (including whether they are pointers).
+//
+// The labrpc package simulates a lossy network, in which servers
+// may be unreachable, and in which requests and replies may be lost.
+// Call() sends a request and waits for a reply. If a reply arrives
+// within a timeout interval, Call() returns true; otherwise
+// Call() returns false. Thus Call() may not return for a while.
+// A false return can be caused by a dead server, a live server that
+// can't be reached, a lost request, or a lost reply.
+//
+// Call() is guaranteed to return (perhaps after a delay) *except* if the
+// handler function on the server side does not return.  Thus there
+// is no need to implement your own timeouts around Call().
+//
+// look at the comments in ../labrpc/labrpc.go for more details.
+//
+// if you're having trouble getting RPC to work, check that you've
+// capitalized all field names in structs passed over RPC, and
+// that the caller passes the address of the reply struct with &, not
+// the struct itself.
+func (rf *Raft) sendRequestVote(server int, args *RequestVoteArgs, reply *RequestVoteReply) bool {
+	DPrintf("[sendRequestVote.start] %d -> %d, request: %+v", args.CandidateId, server, args)
+	ok := rf.peers[server].Call("Raft.RequestVote", args, reply)
+	DPrintf("[sendRequestVote.end] %d -> %d, request: %+v, reply: %+v, result: %t", args.CandidateId, server, args, reply, ok)
+	return ok
+}
+
+// RequestVote RPC handler.
+func (rf *Raft) RequestVote(args *RequestVoteArgs, reply *RequestVoteReply) {
+	// Your code here (2A, 2B).
+	DPrintf("[RequestVote.start] %d -> %d (votedFor: %d), request: %+v, reply: %+v", args.CandidateId, rf.me, rf.votedFor, args, reply)
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+
+	reply.Term = rf.currentTerm
+	reply.VoteGranted = false
+
+	// Reply false if term < currentTerm (5.1)
+	if args.Term < rf.currentTerm {
+		return
+	}
+	if args.Term > rf.currentTerm {
+		rf.becomeFollower(args.Term)
+	}
+
+	if (rf.votedFor == -1 || rf.votedFor == args.CandidateId) && rf.logBehindThan(args) {
+		rf.votedFor = args.CandidateId
+		rf.persist()
+		reply.VoteGranted = true
+		// Reset election timer: grant vote to candidate.
+		rf.receiveHB = true
+	}
+
+	DPrintf("[RequestVote.end] %d -> %d (votedFor: %d), request: %+v, reply: %+v", args.CandidateId, rf.me, rf.votedFor, args, reply)
+}

--- a/src/raft/leader.go
+++ b/src/raft/leader.go
@@ -1,1 +1,0 @@
-package raft

--- a/src/raft/snapshot.go
+++ b/src/raft/snapshot.go
@@ -1,0 +1,155 @@
+package raft
+
+import (
+	"fmt"
+	"time"
+)
+
+// the service says it has created a snapshot that has
+// all info up to and including index. this means the
+// service no longer needs the log through (and including)
+// that index. Raft should now trim its log as much as possible.
+func (rf *Raft) Snapshot(index int, snapshot []byte) {
+	// Your code here (2D).
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+
+	DPrintf("[Snapshot.start] %d, index: %d, lastIncludedIndex: %d", rf.me, index, rf.lastIncludedIndex)
+	// If the snapshot is older than the current snapshot, ignore it.
+	if index <= rf.lastIncludedIndex {
+		return
+	}
+	if index > rf.lastApplied || index > rf.commitIndex {
+		panic(fmt.Sprintf("Snapshot shouldn't be created from an index (%d) larger than lastApplied or commitIndex (%d, %d)",
+			index, rf.lastApplied, rf.commitIndex))
+	}
+
+	idx := rf.logIdx(index)
+	rf.snapshot = snapshot
+	rf.lastIncludedTerm = rf.logs[idx].Term
+	rf.lastIncludedIndex = rf.logs[idx].Index
+	rf.logs = rf.logs[idx+1:]
+	rf.persist()
+	DPrintf("[Snapshot.end] %d, index: %d, lastIncludedIndex: %d", rf.me, index, rf.lastIncludedIndex)
+}
+
+func (rf *Raft) sendInstallSnapshotToOne(i int) {
+	rf.mu.Lock()
+	request := InstallSnapshotArgs{
+		Term:     rf.currentTerm,
+		LeaderId: rf.me,
+	}
+	rf.mu.Unlock()
+
+	for !rf.killed() {
+		rf.mu.Lock()
+		if !rf.checkTermAndRole(request.Term, LEADER) {
+			rf.mu.Unlock()
+			return
+		}
+		if rf.matchIndex[i] >= rf.lastIncludedIndex {
+			rf.mu.Unlock()
+			return
+		}
+
+		request.LastIncludedTerm = rf.lastIncludedTerm
+		request.LastIncludedIndex = rf.lastIncludedIndex
+		request.Data = rf.snapshot
+		reply := InstallSnapshotReply{}
+		rf.mu.Unlock()
+
+		ok := rf.sendInstallSnapshot(i, &request, &reply)
+		if !ok {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+
+		rf.mu.Lock()
+		if !rf.checkTermAndRole(request.Term, LEADER) {
+			rf.mu.Unlock()
+			return
+		}
+		if reply.Term > rf.currentTerm {
+			rf.becomeFollower(reply.Term)
+			rf.mu.Unlock()
+			return
+		}
+
+		rf.matchIndex[i] = maxInt(rf.matchIndex[i], request.LastIncludedIndex)
+		rf.nextIndex[i] = rf.matchIndex[i] + 1
+		rf.mu.Unlock()
+	}
+}
+
+// sendInstallSnapshot is called by leader to send snapshot to follower. When leader
+// sends log entries (`AppendEntries` RPC) and finds that follower's `nextIndex` is
+// smaller than the index of its first log entry, it means the follower's log is
+// too old and requires a snapshot. In this case, leader will send a snapshot insead.
+func (rf *Raft) sendInstallSnapshot(server int, args *InstallSnapshotArgs, reply *InstallSnapshotReply) bool {
+	ok := rf.peers[server].Call("Raft.InstallSnapshot", args, reply)
+	return ok
+}
+
+// InstallSnapshot is the RPC handler for follower to receive and install a snapshot
+// from leader.
+//
+// When a Raft server receives an snapshot, the following may happen, assuming the snapshot is indeed from leader:
+// 1. the snapshot is older than existing one: ignore the request.
+// 2. the snapshot is newer than existing one, but older compared to `lastApplied`: ignore the request.
+// 3. the snapshot is newer than existing one and `lastApplied`, but older than `commitIndex`: update snapshot and logs, apply.
+// 4. the snapshot is newer than all logs: update snapshot and remove all logs, apply.
+// 5. the snapshot's lastIncludedTerm and lastIncludedIndex conflict with existing logs: same as 4.
+func (rf *Raft) InstallSnapshot(args *InstallSnapshotArgs, reply *InstallSnapshotReply) {
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+	DPrintf("[InstallSnapshot.start] %d -> %d, snapshot term: %d, snapshot index: %d", args.LeaderId, rf.me, args.LastIncludedTerm, args.LastIncludedIndex)
+	reply.Term = rf.currentTerm
+	if args.Term < rf.currentTerm {
+		return
+	}
+
+	rf.receiveHB = true
+	if args.Term > rf.currentTerm {
+		rf.becomeFollower(args.Term)
+	}
+
+	// nothing to process if
+	// (1). the snapshot is older than the current snapshot.
+	if args.LastIncludedIndex <= rf.lastIncludedIndex {
+		return
+	}
+	// (2). the snapshot didn't provide any new information known to state machine.
+	if args.LastIncludedIndex <= rf.lastApplied {
+		return
+	}
+
+	// The new snapshot has new data than previous snapshot.
+	// pre-calculate the idx of `LastIncludedIndex` in the current "snapshot + logs"
+	// before they're overwritten. Used in step 6.
+	oldIdx := rf.logIdx(args.LastIncludedIndex)
+
+	// 5. Save snapshot, discard any existing or partial snapshot with a smaller index
+	if rf.lastIncludedIndex < args.LastIncludedIndex {
+		rf.snapshot = args.Data
+		rf.lastIncludedTerm = args.LastIncludedTerm
+		rf.lastIncludedIndex = args.LastIncludedIndex
+	}
+
+	if oldIdx != -1 && oldIdx < len(rf.logs) && rf.logs[oldIdx].Term == args.LastIncludedTerm {
+		// 6. If existing (applied) log entry has same index and term as snapshot’s last included entry,
+		// retain log entries following it
+		rf.logs = rf.logs[oldIdx+1:]
+	} else {
+		// 7. Discard the entire log
+		rf.logs = []LogEntry{}
+	}
+
+	// 8. Reset state machine using snapshot contents
+	rf.persist()
+	if rf.commitIndex < args.LastIncludedIndex {
+		rf.commitIndex = args.LastIncludedIndex
+		go rf.startApplyCommit()
+	}
+
+	DPrintf("[InstallSnapshot.end] %d -> %d, snapshot term: %d, snapshot index: %d", args.LeaderId, rf.me, args.LastIncludedTerm, args.LastIncludedIndex)
+}

--- a/src/raft/types.go
+++ b/src/raft/types.go
@@ -4,9 +4,6 @@ const (
 	FOLLOWER  = "FOLLOWER"
 	CANDIDATE = "CANDIDATE"
 	LEADER    = "LEADER"
-
-	TypeAppendEntries = 1
-	TypeHeartbeat     = 2
 )
 
 const (
@@ -17,6 +14,50 @@ const (
 	ELECTION_TIMEOUT_MIN = 300
 	ELECTION_TIMEOUT_JIT = 150
 )
+
+// as each Raft peer becomes aware that successive log entries are
+// committed, the peer should send an ApplyMsg to the service (or
+// tester) on the same server, via the applyCh passed to Make(). set
+// CommandValid to true to indicate that the ApplyMsg contains a newly
+// committed log entry.
+//
+// in part 2D you'll want to send other kinds of messages (e.g.,
+// snapshots) on the applyCh, but set CommandValid to false for these
+// other uses.
+type ApplyMsg struct {
+	CommandValid bool
+	Command      interface{}
+	CommandIndex int
+
+	// For 2D:
+	SnapshotValid bool
+	Snapshot      []byte
+	SnapshotTerm  int
+	SnapshotIndex int
+}
+
+// example RequestVote RPC arguments structure.
+// field names must start with capital letters!
+type RequestVoteArgs struct {
+	// Your data here (2A, 2B).
+	Term        int
+	CandidateId int
+	// candidate's last log entry.
+	// they are used to ensure election restriction (paper 5.4.1).
+	// a candidate receives vote for a follower only if the candidate's log
+	// is more up-to-date than the follower's.
+	// "up-to-date" is measured by (term, index) of the last log entry.
+	LastLogTerm  int
+	LastLogIndex int
+}
+
+// example RequestVote RPC reply structure.
+// field names must start with capital letters!
+type RequestVoteReply struct {
+	// Your data here (2A).
+	Term        int
+	VoteGranted bool
+}
 
 // AppendEntriesArgs is a RPC request struct for AppendEntries RPC.
 type AppendEntriesArgs struct {
@@ -46,4 +87,18 @@ type LogEntry struct {
 	Command interface{}
 	Term    int
 	Index   int
+}
+
+// InstallSnapshotArgs is a RPC request struct for InstallSnapshot RPC.
+type InstallSnapshotArgs struct {
+	Term              int
+	LeaderId          int
+	LastIncludedIndex int
+	LastIncludedTerm  int
+	Data              []byte
+}
+
+// InstallSnapshotReply is a RPC reply from InstallSnapshot RPC.
+type InstallSnapshotReply struct {
+	Term int // currentTerm of the receiving server, for leader to update itself if necessary
 }

--- a/src/raft/util.go
+++ b/src/raft/util.go
@@ -11,3 +11,17 @@ func DPrintf(format string, a ...interface{}) (n int, err error) {
 	}
 	return
 }
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
Some Raft debug learning:

1. While retrying RPCs (`AppendEntries`, `InstallSnapshot`), update request arguments with caution, especially `currentTerm`.
2. Check `Term` and `Role` BEFORE AND AFTER RPC calls. For example, when sending `AppendEntries` RPC, you need to check if the server is still `LEADER` before sending the RPC request. Upon receiving a response, you need to check if the server's `currentTerm` (== `request.Term`) and `status` (== 'LEADER`) are still valid. The pre-request check is very easily ignored when you retry the RPC and update `AppendEntriesArgs.Term = rf.currentTerm`.
3. Having a dedicated single goroutine `applier` to apply committed log entries to state machine causes less bugs. Whenever you want to apply some entries, you just notify that `applier` goroutine (e.g., via a channel).