### PR TITLE
lab3a - pass 100 test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,18 @@ $ ./go-test-many.sh 500 32 2C
   - [x] Lab 2C: Persist Raft data [pass 497~500/500, rare failure means an optimization might necessary]
   - [x] Lab 2D: log compaction
 - [ ] [Lab 3: Key-Value storage based on Raft](https://pdos.csail.mit.edu/6.824/labs/lab-kvraft.html)
-  - [ ] Lab 3A: KV storage without snapshots
+  - [x] Lab 3A: KV storage without snapshots [pass 100/100 test runs (`./go-test-many.sh 100 20 3A`)]
   - [ ] Lab 3B: KV storage with snapshots
 - [ ] [Lab 4: Sharded Key-Value storage](https://pdos.csail.mit.edu/6.824/labs/lab-shard.html)
   - [ ] Lab 4A: The Shard controller
   - [ ] Lab 4B: Sharded Key/Value Server
+
+## Lab 3A Notes
+
+- To make it easier to achieve linearizability, ensure only one outstanding RPC per client/clerk.
+You can achieve this by locking whole `Get/PutAppend` calls.
+- Keeping only one outstanding RPC per client/clerk also makes the duplication table smaller.
+You just need to keep the latest committed request id per client/clerk, instead of all committed request ids.
+- Duplicated client requests may happen at two places: (1). previous request is not committed (e.g., failed at server or Raft module); (2). previous request is committed, but the reply is lost (e.g., failed at network).
+- When applying a message from Raft, you need to check if it's a duplicate, by checking if the request id is smaller than or equal to the latest committed request id.
+- Before sending a request from server to its Raft module, you need to check if it's a duplicate, by checking if the request id is smaller than or equal to the latest committed request id.

--- a/src/kvraft/client.go
+++ b/src/kvraft/client.go
@@ -1,13 +1,22 @@
 package kvraft
 
-import "6.5840/labrpc"
-import "crypto/rand"
-import "math/big"
+import (
+	"crypto/rand"
+	"math/big"
+	"sync"
+	"time"
 
+	"6.5840/labrpc"
+)
 
 type Clerk struct {
 	servers []*labrpc.ClientEnd
 	// You will have to modify this struct.
+
+	mu     sync.Mutex
+	leader int
+	uid    int64
+	rid    int64
 }
 
 func nrand() int64 {
@@ -21,7 +30,19 @@ func MakeClerk(servers []*labrpc.ClientEnd) *Clerk {
 	ck := new(Clerk)
 	ck.servers = servers
 	// You'll have to add code here.
+	ck.leader = 0
+	ck.uid = nrand()
+	// request id (rid) starts from 1 and increments by 1 for each request.
+	ck.rid = 1
+
+	DPrintf("Clerk %d created.", ck.uid)
 	return ck
+}
+
+func (ck *Clerk) requestId() int64 {
+	rid := ck.rid
+	ck.rid++
+	return rid
 }
 
 // fetch the current value for a key.
@@ -35,9 +56,34 @@ func MakeClerk(servers []*labrpc.ClientEnd) *Clerk {
 // must match the declared types of the RPC handler function's
 // arguments. and reply must be passed as a pointer.
 func (ck *Clerk) Get(key string) string {
-
 	// You will have to modify this function.
-	return ""
+	ck.mu.Lock()
+	defer ck.mu.Unlock()
+	leader := ck.leader
+	args := GetArgs{Key: key, UID: ck.uid, RID: ck.requestId()}
+
+	var reply GetReply
+	for {
+		DPrintf("[Get.Start] clerk %d -> server %d, request: %+v", ck.uid, leader, args)
+		reply = GetReply{}
+		ok := ck.servers[leader].Call("KVServer.Get", &args, &reply)
+		if ok && (reply.Err == OK || reply.Err == ErrNoKey) {
+			break
+		}
+
+		// try next server if `ck.leader` is not yet updated.
+		if ck.leader == leader {
+			ck.leader = (ck.leader + 1) % len(ck.servers)
+			leader = ck.leader
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	DPrintf("[Get.End] clerk %d -> server %d, reply: %+v", ck.uid, leader, reply)
+	if reply.Err == ErrNoKey {
+		return ""
+	}
+	return reply.Value
 }
 
 // shared by Put and Append.
@@ -50,6 +96,32 @@ func (ck *Clerk) Get(key string) string {
 // arguments. and reply must be passed as a pointer.
 func (ck *Clerk) PutAppend(key string, value string, op string) {
 	// You will have to modify this function.
+	ck.mu.Lock()
+	defer ck.mu.Unlock()
+	leader := ck.leader
+	args := PutAppendArgs{Key: key, Value: value, Op: op, UID: ck.uid, RID: ck.requestId()}
+
+	var reply PutAppendReply
+	for {
+		DPrintf("[PutAppend.Start] clerk %d -> server %d, request: %+v", ck.uid, leader, args)
+		reply = PutAppendReply{}
+		ok := ck.servers[leader].Call("KVServer.PutAppend", &args, &reply)
+		if ok && reply.Err == OK {
+			break
+		}
+
+		// try next server if `ck.leader` is not yet updated.
+		if ck.leader == leader {
+			ck.leader = (ck.leader + 1) % len(ck.servers)
+			leader = ck.leader
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	DPrintf("[PutAppend.End] clerk %d -> server %d, reply: %+v", ck.uid, leader, reply)
+	if reply.Err != OK {
+		panic("PutAppend panic: " + reply.Err)
+	}
 }
 
 func (ck *Clerk) Put(key string, value string) {

--- a/src/kvraft/common.go
+++ b/src/kvraft/common.go
@@ -4,6 +4,10 @@ const (
 	OK             = "OK"
 	ErrNoKey       = "ErrNoKey"
 	ErrWrongLeader = "ErrWrongLeader"
+
+	OpPut    = "Put"
+	OpAppend = "Append"
+	OpGet    = "Get"
 )
 
 type Err string
@@ -16,6 +20,12 @@ type PutAppendArgs struct {
 	// You'll have to add definitions here.
 	// Field names must start with capital letters,
 	// otherwise RPC will break.
+	// To uniquely identify each request from every clerk client,
+	// we use a globally-unique `UID` to identify each clerk client,
+	// then within each clerk client, we use `RID` (monotonically increase from 0)
+	// to identify each request.
+	UID int64
+	RID int64
 }
 
 type PutAppendReply struct {
@@ -25,6 +35,8 @@ type PutAppendReply struct {
 type GetArgs struct {
 	Key string
 	// You'll have to add definitions here.
+	UID int64
+	RID int64
 }
 
 type GetReply struct {

--- a/src/kvraft/go-test-many.sh
+++ b/src/kvraft/go-test-many.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+#
+# Script for running `go test` a bunch of times, in parallel, storing the test
+# output as you go, and showing a nice status output telling you how you're
+# doing.
+#
+# Normally, you should be able to execute this script with
+#
+#   ./go-test-many.sh
+#
+# and it should do The Right Thing(tm) by default. However, it does take some
+# arguments so that you can tweak it for your testing setup. To understand
+# them, we should first go quickly through what exactly this script does.
+#
+# First, it compiles your Go program (using go test -c) to ensure that all the
+# tests are run on the same codebase, and to speed up the testing. Then, it
+# runs the tester some number of times. It will run some number of testers in
+# parallel, and when that number of running testers has been reached, it will
+# wait for the oldest one it spawned to finish before spawning another. The
+# output from each test i is stored in test-$i.log and test-$i.err (STDOUT and
+# STDERR respectively).
+#
+# The options you can specify on the command line are:
+#
+#   1) how many times to run the tester (defaults to 100)
+#   2) how many testers to run in parallel (defaults to the number of CPUs)
+#   3) which subset of the tests to run (default to all tests)
+#
+# 3) is simply a regex that is passed to the tester under -test.run; any tests
+# matching the regex will be run.
+#
+# The script is smart enough to clean up after itself if you kill it
+# (in-progress tests are killed, their output is discarded, and no failure
+# message is printed), and will automatically continue from where it left off
+# if you kill it and then start it again.
+#
+# By now, you know everything that happens below.
+# If you still want to read the code, go ahead.
+
+if [ $# -eq 1 ] && [ "$1" = "--help" ]; then
+	echo "Usage: $0 [RUNS=100] [PARALLELISM=#cpus] [TESTPATTERN='']"
+	exit 1
+fi
+
+# If the tests don't even build, don't bother. Also, this gives us a static
+# tester binary for higher performance and higher reproducability.
+if ! go test -c -o tester; then
+	echo -e "\e[1;31mERROR: Build failed\e[0m"
+	exit 1
+fi
+
+# Default to 100 runs unless otherwise specified
+runs=100
+if [ $# -gt 0 ]; then
+	runs="$1"
+fi
+
+# Default to one tester per CPU unless otherwise specified
+parallelism=$(grep -c processor /proc/cpuinfo)
+if [ $# -gt 1 ]; then
+	parallelism="$2"
+fi
+
+# Default to no test filtering unless otherwise specified
+test=""
+if [ $# -gt 2 ]; then
+	test="$3"
+fi
+
+# Figure out where we left off
+logs=$(find . -maxdepth 1 -name 'test-*.log' -type f -printf '.' | wc -c)
+success=$(grep -E '^PASS$' test-*.log | wc -l)
+((failed = logs - success))
+
+# Finish checks the exit status of the tester with the given PID, updates the
+# success/failed counters appropriately, and prints a pretty message.
+finish() {
+	if ! wait "$1"; then
+		if command -v notify-send >/dev/null 2>&1 &&((failed == 0)); then
+			notify-send -i weather-storm "Tests started failing" \
+				"$(pwd)\n$(grep FAIL: -- *.log | sed -e 's/.*FAIL: / - /' -e 's/ (.*)//' | sort -u)"
+		fi
+		((failed += 1))
+	else
+		((success += 1))
+	fi
+
+	if [ "$failed" -eq 0 ]; then
+		printf "\e[1;32m";
+	else
+		printf "\e[1;31m";
+	fi
+
+	printf "Done %03d/%d; %d ok, %d failed\n\e[0m" \
+		$((success+failed)) \
+		"$runs" \
+		"$success" \
+		"$failed"
+}
+
+waits=() # which tester PIDs are we waiting on?
+is=()    # and which iteration does each one correspond to?
+
+# Cleanup is called when the process is killed.
+# It kills any remaining tests and removes their output files before exiting.
+cleanup() {
+	for pid in "${waits[@]}"; do
+		kill "$pid"
+		wait "$pid"
+		rm -rf "test-${is[0]}.err" "test-${is[0]}.log"
+		is=("${is[@]:1}")
+	done
+	exit 0
+}
+trap cleanup SIGHUP SIGINT SIGTERM
+
+# Run remaining iterations (we may already have run some)
+for i in $(seq "$((success+failed+1))" "$runs"); do
+	# If we have already spawned the max # of testers, wait for one to
+	# finish. We'll wait for the oldest one beause it's easy.
+	if [[ ${#waits[@]} -eq "$parallelism" ]]; then
+		finish "${waits[0]}"
+		waits=("${waits[@]:1}") # this funky syntax removes the first
+		is=("${is[@]:1}")       # element from the array
+	fi
+
+	# Store this tester's iteration index
+	# It's important that this happens before appending to waits(),
+	# otherwise we could get an out-of-bounds in cleanup()
+	is=("${is[@]}" $i)
+
+	# Run the tester, passing -test.run if necessary
+	if [[ -z "$test" ]]; then
+		./tester -test.v 2> "test-${i}.err" > "test-${i}.log" &
+		pid=$!
+	else
+		./tester -test.run "$test" -test.v 2> "test-${i}.err" > "test-${i}.log" &
+		pid=$!
+	fi
+
+	# Remember the tester's PID so we can wait on it later
+	waits=("${waits[@]}" $pid)
+done
+
+# Wait for remaining testers
+for pid in "${waits[@]}"; do
+	finish "$pid"
+done
+
+if ((failed>0)); then
+	exit 1
+fi
+exit 0

--- a/src/kvraft/server.go
+++ b/src/kvraft/server.go
@@ -1,12 +1,14 @@
 package kvraft
 
 import (
-	"6.5840/labgob"
-	"6.5840/labrpc"
-	"6.5840/raft"
 	"log"
 	"sync"
 	"sync/atomic"
+	"time"
+
+	"6.5840/labgob"
+	"6.5840/labrpc"
+	"6.5840/raft"
 )
 
 const Debug = false
@@ -18,13 +20,36 @@ func DPrintf(format string, a ...interface{}) (n int, err error) {
 	return
 }
 
+type Status string
 
+// Op is the `Command` struct in Raft that `KVServer` sends to Raft for consensus,
+// and Raft sends back for commit/apply after consensus is reached.
 type Op struct {
 	// Your definitions here.
 	// Field names must start with capital letters,
 	// otherwise RPC will break.
+	Type  string // "Put" or "Append" or "Get"
+	Key   string
+	Value string
+	UID   int64
+	RID   int64
 }
 
+func OpFromGetArgs(args *GetArgs) Op {
+	return Op{Type: OpGet, Key: args.Key, UID: args.UID, RID: args.RID}
+}
+
+func OpFromPutAppendArgs(args *PutAppendArgs) Op {
+	return Op{Type: args.Op, Key: args.Key, Value: args.Value, UID: args.UID, RID: args.RID}
+}
+
+// KVServer receives requests from Clerk and sends `Op` to Raft for consensus.
+// After consensus is reached (KVServer receives `ApplyMsg` from Raft), KVServer
+// sends the result back to Clerk.
+// KVServer will fail a Clerk request if:
+// 1. Raft cannot reach consensus after a fixed number of retries.
+// 2. KVServer notices that Raft committed a log entry with the same index, but
+// different `UID`+`RID`, meaning the other ones will be failed utimately.
 type KVServer struct {
 	mu      sync.Mutex
 	me      int
@@ -35,15 +60,95 @@ type KVServer struct {
 	maxraftstate int // snapshot if log grows this big
 
 	// Your definitions here.
-}
+	// `data` stores the latest key-value pairs with all committed/applied log entries.
+	// `op2status` stores the status of each request (`RID`) from every clerk client (`UID`).
+	// `op2value` stores the value of each request (`RID`) from every clerk client (`UID`),
+	// which is used to detect duplicate requests.
+	data map[string]string // key-value store
 
+	// duplicate detection table:
+	// `uid2rid` stores the latest `RID` from every clerk client (`UID`), so no duplicate
+	// requests from the same client will be applied when receiving `ApplyMsg` from Raft.
+	// `uid2val` stores the latest value, so when a duplication did happen, the server
+	// can return the value directly.
+	uid2rid map[int64]int64  // UID -> latest RID from this UID
+	uid2val map[int64]string // UID -> latest value from this UID
+
+	// `index2uid` makes it possible to detect request failure faster.
+	// If an `ApplyMsg` is received and its `UID` conflicts with the one in `index2uid`,
+	// that means the request from `index2uid[index]` has failed, since a conflicting
+	// command has been committed in the same index.
+	index2uid map[int]int64 // log entry index -> UID
+
+	killedCh chan struct{}
+}
 
 func (kv *KVServer) Get(args *GetArgs, reply *GetReply) {
 	// Your code here.
+	reply.Err = kv.sendOpToRaft(OpFromGetArgs(args))
+	if reply.Err == OK {
+		kv.mu.Lock()
+		defer kv.mu.Unlock()
+		reply.Value = kv.uid2val[args.UID]
+		if reply.Value == "" {
+			reply.Err = ErrNoKey
+		}
+
+	}
 }
 
 func (kv *KVServer) PutAppend(args *PutAppendArgs, reply *PutAppendReply) {
 	// Your code here.
+	reply.Err = kv.sendOpToRaft(OpFromPutAppendArgs(args))
+
+}
+
+func (kv *KVServer) sendOpToRaft(op Op) Err {
+	kv.mu.Lock()
+	if _, ok := kv.uid2rid[op.UID]; !ok {
+		kv.uid2rid[op.UID] = 0
+	}
+	rid := kv.uid2rid[op.UID]
+	switch {
+	case op.RID < rid:
+		kv.mu.Unlock()
+		DPrintf("[PANIC][sendOpToRaft] %d, too small RID from UID %d. expected: >= %d, actual: %d", kv.me, op.UID, rid, op.RID)
+		return ErrWrongLeader
+	case op.RID == rid:
+		kv.mu.Unlock()
+		return OK
+	case op.RID > rid:
+		// new op, proceed below
+		kv.mu.Unlock()
+	}
+
+	index, _, isLeader := kv.rf.Start(op)
+	if !isLeader {
+		return ErrWrongLeader
+	}
+	return kv.waitOpToFinish(index, op.UID, op.RID)
+}
+
+func (kv *KVServer) waitOpToFinish(index int, uid, rid int64) Err {
+	i := 0
+	for !kv.killed() && i < 70 {
+		i++
+
+		kv.mu.Lock()
+		if committedUid, ok := kv.index2uid[index]; ok {
+			var err Err
+			if committedUid == uid && kv.uid2rid[uid] == rid {
+				err = OK
+			} else {
+				err = ErrWrongLeader
+			}
+			kv.mu.Unlock()
+			return err
+		}
+		kv.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+	return ErrWrongLeader
 }
 
 // the tester calls Kill() when a KVServer instance won't
@@ -58,11 +163,90 @@ func (kv *KVServer) Kill() {
 	atomic.StoreInt32(&kv.dead, 1)
 	kv.rf.Kill()
 	// Your code here, if desired.
+	kv.killedCh <- struct{}{}
 }
 
 func (kv *KVServer) killed() bool {
 	z := atomic.LoadInt32(&kv.dead)
 	return z == 1
+}
+
+func (kv *KVServer) applier() {
+	for !kv.killed() {
+		select {
+		case <-kv.killedCh:
+			return
+		case msg := <-kv.applyCh:
+			if msg.CommandValid {
+				kv.applyCommand(&msg)
+			} else if msg.SnapshotValid {
+				kv.applySnapshot(&msg)
+			} else {
+				panic("unknown message type")
+			}
+		}
+	}
+}
+
+// applyCommand applies an `ApplyMsg` received from Raft. While applying, the following may happen:
+// 1. A brand new message that the server never sees (e.g. as a follower)
+// 2. The message is the response for an `Op` initiated by the server (e.g. as a leader)
+// 3. The message conflict with an ongoing `Op` initiated by the server (e.g. as an expired leader)
+func (kv *KVServer) applyCommand(msg *raft.ApplyMsg) {
+	op := msg.Command.(Op)
+	index := msg.CommandIndex
+
+	kv.mu.Lock()
+	defer kv.mu.Unlock()
+
+	// duplicate `Op`, return directly.
+	switch {
+	case op.RID < kv.uid2rid[op.UID]:
+		DPrintf("[PANIC][applyCommand] %d, found too small RID from %d. expected: %d, actual: %d", kv.me, op.UID, kv.uid2rid[op.UID]+1, op.RID)
+		return
+	case op.RID == kv.uid2rid[op.UID]:
+		DPrintf("[applyCommand] %d, found duplicate RID from %d. expected: %d, actual: %d", kv.me, op.UID, kv.uid2rid[op.UID]+1, op.RID)
+		return
+	case op.RID == kv.uid2rid[op.UID]+1:
+	// expected case
+	case op.RID > kv.uid2rid[op.UID]+1:
+		DPrintf("[PANIC][applyCommand] %d, found too large RID from %d. expected: %d, actual: %d", kv.me, op.UID, kv.uid2rid[op.UID]+1, op.RID)
+		return
+	}
+
+	// for debug/log: when applying command at `index`, `index-1` should already be applied, and `index+1` should not.
+	if _, ok := kv.index2uid[index-1]; !ok && index > 1 {
+		DPrintf("[PANIC][applyCommand] %d, miss unexpected index: %d, applying: %d", kv.me, index-1, index)
+	}
+	if _, ok := kv.index2uid[index+1]; ok {
+		DPrintf("[PANIC][applyCommand] %d, found unexpected index: %d, applying: %d", kv.me, index+1, index)
+	}
+
+	DPrintf("[applyCommand] %d, applying index: %d, UID: %d, RID: %d", kv.me, index, op.UID, op.RID)
+
+	// update kv server data
+	kv.index2uid[index] = op.UID
+
+	kv.uid2rid[op.UID] = op.RID
+	switch op.Type {
+	case OpGet:
+		if _, ok := kv.data[op.Key]; !ok {
+			kv.uid2val[op.UID] = ""
+		} else {
+			kv.uid2val[op.UID] = kv.data[op.Key]
+		}
+	case OpPut:
+		kv.data[op.Key] = op.Value
+	case OpAppend:
+		if _, ok := kv.data[op.Key]; !ok {
+			kv.data[op.Key] = ""
+		}
+		kv.data[op.Key] += op.Value
+	}
+}
+
+func (kv *KVServer) applySnapshot(msg *raft.ApplyMsg) {
+
 }
 
 // servers[] contains the ports of the set of
@@ -92,6 +276,14 @@ func StartKVServer(servers []*labrpc.ClientEnd, me int, persister *raft.Persiste
 	kv.rf = raft.Make(servers, me, persister, kv.applyCh)
 
 	// You may need initialization code here.
+	kv.data = make(map[string]string)
+	kv.uid2rid = make(map[int64]int64)
+	kv.uid2val = make(map[int64]string)
+	kv.index2uid = make(map[int]int64)
+
+	kv.killedCh = make(chan struct{}, 1)
+
+	go kv.applier()
 
 	return kv
 }

--- a/src/raft/snapshot.go
+++ b/src/raft/snapshot.go
@@ -59,11 +59,6 @@ func (rf *Raft) sendInstallSnapshotToOne(i int) {
 		rf.mu.Unlock()
 
 		ok := rf.sendInstallSnapshot(i, &request, &reply)
-		if !ok {
-			time.Sleep(10 * time.Millisecond)
-			continue
-		}
-
 		rf.mu.Lock()
 		if !rf.checkTermAndRole(request.Term, LEADER) {
 			rf.mu.Unlock()
@@ -73,6 +68,11 @@ func (rf *Raft) sendInstallSnapshotToOne(i int) {
 			rf.becomeFollower(reply.Term)
 			rf.mu.Unlock()
 			return
+		}
+		if !ok {
+			rf.mu.Unlock()
+			time.Sleep(10 * time.Millisecond)
+			continue
 		}
 
 		rf.matchIndex[i] = maxInt(rf.matchIndex[i], request.LastIncludedIndex)

--- a/src/raft/types.go
+++ b/src/raft/types.go
@@ -1,5 +1,7 @@
 package raft
 
+import "fmt"
+
 const (
 	FOLLOWER  = "FOLLOWER"
 	CANDIDATE = "CANDIDATE"
@@ -36,6 +38,10 @@ type ApplyMsg struct {
 	SnapshotIndex int
 }
 
+func (msg ApplyMsg) String() string {
+	return fmt.Sprintf("ApplyMsg{CommandValid: %v, Command: %v, CommandIndex: %v, SnapshotValid: %v, SnapshotTerm: %v, SnapshotIndex: %v}", msg.CommandValid, msg.Command, msg.CommandIndex, msg.SnapshotValid, msg.SnapshotTerm, msg.SnapshotIndex)
+}
+
 // example RequestVote RPC arguments structure.
 // field names must start with capital letters!
 type RequestVoteArgs struct {
@@ -51,12 +57,20 @@ type RequestVoteArgs struct {
 	LastLogIndex int
 }
 
+func (args RequestVoteArgs) String() string {
+	return fmt.Sprintf("RequestVoteArgs{Term: %v, CandidateId: %v, LastLogTerm: %v, LastLogIndex: %v}", args.Term, args.CandidateId, args.LastLogTerm, args.LastLogIndex)
+}
+
 // example RequestVote RPC reply structure.
 // field names must start with capital letters!
 type RequestVoteReply struct {
 	// Your data here (2A).
 	Term        int
 	VoteGranted bool
+}
+
+func (reply RequestVoteReply) String() string {
+	return fmt.Sprintf("RequestVoteReply{Term: %v, VoteGranted: %t}", reply.Term, reply.VoteGranted)
 }
 
 // AppendEntriesArgs is a RPC request struct for AppendEntries RPC.
@@ -71,6 +85,10 @@ type AppendEntriesArgs struct {
 	LeaderCommitIndex int
 }
 
+func (args AppendEntriesArgs) String() string {
+	return fmt.Sprintf("AppendEntriesArgs{Type: %v, Term: %v, LeaderId: %v, PrevLogTerm: %v, PrevLogIndex: %v, #(Entries): %v, LeaderCommitIndex: %v}", args.Type, args.Term, args.LeaderId, args.PrevLogTerm, args.PrevLogIndex, len(args.Entries), args.LeaderCommitIndex)
+}
+
 // AppendEntriesReply is a RPC reply from AppendEntries RPC.
 type AppendEntriesReply struct {
 	Term    int
@@ -80,6 +98,10 @@ type AppendEntriesReply struct {
 	XTerm  int // term in the conflicting entry (if any)
 	XIndex int // index of first entry with that term (if any)
 	XLen   int // log length
+}
+
+func (reply AppendEntriesReply) String() string {
+	return fmt.Sprintf("AppendEntriesReply{Term: %v, Success: %t, XTerm: %v, XIndex: %v, XLen: %v}", reply.Term, reply.Success, reply.XTerm, reply.XIndex, reply.XLen)
 }
 
 // LogEntry is a log entry in the log.
@@ -98,7 +120,15 @@ type InstallSnapshotArgs struct {
 	Data              []byte
 }
 
+func (args InstallSnapshotArgs) String() string {
+	return fmt.Sprintf("InstallSnapshotArgs{Term: %v, LeaderId: %v, LastIncludedIndex: %v, LastIncludedTerm: %v}", args.Term, args.LeaderId, args.LastIncludedIndex, args.LastIncludedTerm)
+}
+
 // InstallSnapshotReply is a RPC reply from InstallSnapshot RPC.
 type InstallSnapshotReply struct {
 	Term int // currentTerm of the receiving server, for leader to update itself if necessary
+}
+
+func (reply InstallSnapshotReply) String() string {
+	return fmt.Sprintf("InstallSnapshotReply{Term: %v}", reply.Term)
 }


### PR DESCRIPTION
- Implement lab 3a.
- Refactor leader election to match other Raft RPC structure.
- For Raft RPCs, do post RPC checks first and then retry (so it can early return if needed instead of keeping retry).